### PR TITLE
Behavioral change-- when no groups are specified, fields are outputted

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/go-version"
-	"github.com/liip/sheriff"
+	"github.com/launchdarkly-labs/sheriff"
 )
 
 type User struct {

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/liip/sheriff
+package: github.com/launchdarkly-labs/sheriff
 import:
 - package: github.com/hashicorp/go-version
 testImport:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/launchdarkly-labs/sheriff
+
+go 1.13
+
+require github.com/hashicorp/go-version v1.2.1-0.20191009193637-2046c9d0f0b0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/launchdarkly-labs/sheriff
 
 go 1.13
 
-require github.com/hashicorp/go-version v1.2.1-0.20191009193637-2046c9d0f0b0
+require (
+	github.com/hashicorp/go-version v1.2.1-0.20191009193637-2046c9d0f0b0
+	github.com/stretchr/testify v1.4.0
+)

--- a/sheriff.go
+++ b/sheriff.go
@@ -128,8 +128,8 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 				if len(groups) == 0 && options.nestedGroupsMap[field.Name] != nil {
 					groups = append(groups, options.nestedGroupsMap[field.Name]...)
 				}
-				shouldShow := listContains(groups, options.Groups)
-				if !shouldShow || len(groups) == 0 {
+				shouldShow := len(groups) == 0 || listContains(groups, options.Groups)
+				if !shouldShow {
 					continue
 				}
 			}

--- a/sheriff.go
+++ b/sheriff.go
@@ -104,15 +104,18 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 			val = val.Elem()
 		}
 
-		// we can skip the group checkif if the field is a composition field
+		// we can skip the group check if if the field is a composition field
 		isEmbeddedField := field.Anonymous && val.Kind() == reflect.Struct
 
 		if isEmbeddedField && field.Type.Kind() == reflect.Struct {
 			tt := field.Type
-			parentGroups := strings.Split(field.Tag.Get("groups"), ",")
-			for i := 0; i < tt.NumField(); i++ {
-				nestedField := tt.Field(i)
-				options.nestedGroupsMap[nestedField.Name] = parentGroups
+			groups := field.Tag.Get("groups")
+			if groups != "" {
+				parentGroups := strings.Split(groups, ",")
+				for i := 0; i < tt.NumField(); i++ {
+					nestedField := tt.Field(i)
+					options.nestedGroupsMap[nestedField.Name] = parentGroups
+				}
 			}
 		}
 

--- a/sheriff.go
+++ b/sheriff.go
@@ -60,8 +60,6 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		options.nestedGroupsMap = make(map[string][]string)
 	}
 
-	checkGroups := len(options.Groups) > 0
-
 	if t.Kind() == reflect.Ptr {
 		// follow pointer
 		t = t.Elem()
@@ -119,19 +117,17 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		}
 
 		if !isEmbeddedField {
-			if checkGroups {
-				var groups []string
-				if field.Tag.Get("groups") != "" {
-					groups = strings.Split(field.Tag.Get("groups"), ",")
-				}
+			var groups []string
+			if field.Tag.Get("groups") != "" {
+				groups = strings.Split(field.Tag.Get("groups"), ",")
+			}
 
-				if len(groups) == 0 && options.nestedGroupsMap[field.Name] != nil {
-					groups = append(groups, options.nestedGroupsMap[field.Name]...)
-				}
-				shouldShow := len(groups) == 0 || listContains(groups, options.Groups)
-				if !shouldShow {
-					continue
-				}
+			if len(groups) == 0 && options.nestedGroupsMap[field.Name] != nil {
+				groups = append(groups, options.nestedGroupsMap[field.Name]...)
+			}
+			shouldShow := len(groups) == 0 || listContains(groups, options.Groups)
+			if !shouldShow {
+				continue
 			}
 
 			if since := field.Tag.Get("since"); since != "" {

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -159,18 +159,8 @@ func TestMarshal_GroupsNoGroups(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected, err := json.Marshal(map[string]interface{}{
-		"default_marshal":       "DefaultMarshal",
-		"only_group_test":       "OnlyGroupTest",
-		"only_group_test_other": "OnlyGroupTestOther",
-		"group_test_and_other":  "GroupTestAndOther",
-		"map_string_struct": map[string]map[string]bool{
-			"firstModel": {
-				"something":      true,
-				"something_else": true,
-			},
-		},
-		"omit_empty":            "OmitEmpty",
-		"omit_empty_group_test": "OmitEmptyGroupTest",
+		"default_marshal": "DefaultMarshal",
+		"omit_empty":      "OmitEmpty",
 	})
 	assert.NoError(t, err)
 
@@ -656,4 +646,32 @@ func TestMarshal_Inet(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
+}
+
+type TestArray struct {
+	Foo []int `json:"foo" groups:"summary"`
+	Bar int   `json:"bar"`
+}
+
+func TestArrayEmpty(t *testing.T) {
+	v := TestArray{
+		Foo: []int{3, 1, 4},
+		Bar: 0,
+	}
+
+	o := &Options{}
+
+	actualMap, err := Marshal(o, v)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"bar": 0,
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+
 }

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -675,3 +675,46 @@ func TestArrayEmpty(t *testing.T) {
 	assert.Equal(t, string(expected), string(actual))
 
 }
+
+type TopLevel struct {
+	NestedAnon
+	Named NestedNamed `json:"named"`
+}
+
+type NestedAnon struct {
+	Foo int `json:"foo"`
+	Bar int `json:"bar"`
+}
+
+type NestedNamed struct {
+	Name string `json:"name" groups:"verbose"`
+}
+
+func TestAnonymousWithNoGroups(t *testing.T) {
+	anon := NestedAnon{
+		Foo: 3,
+		Bar: 4,
+	}
+
+	named := NestedNamed{
+		Name: "KooKoo",
+	}
+	v := TopLevel{anon, named}
+
+	o := &Options{}
+
+	actualMap, err := Marshal(o, v)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"foo":   3,
+		"bar":   4,
+		"named": map[string]interface{}{},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -52,7 +52,9 @@ func TestMarshal_GroupsValidGroup(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected, err := json.Marshal(map[string]interface{}{
+		"default_marshal":       "DefaultMarshal",
 		"only_group_test":       "OnlyGroupTest",
+		"omit_empty":            "OmitEmpty",
 		"omit_empty_group_test": "OmitEmptyGroupTest",
 		"group_test_and_other":  "GroupTestAndOther",
 		"map_string_struct": map[string]map[string]bool{
@@ -90,8 +92,10 @@ func TestMarshal_GroupsValidGroupOmitEmpty(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected, err := json.Marshal(map[string]interface{}{
+		"default_marshal":      "DefaultMarshal",
 		"only_group_test":      "OnlyGroupTest",
 		"group_test_and_other": "GroupTestAndOther",
+		"omit_empty":           "OmitEmpty",
 		"map_string_struct": map[string]map[string]bool{
 			"firstModel": {
 				"something": true,
@@ -126,7 +130,9 @@ func TestMarshal_GroupsInvalidGroup(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]string{})
+	expected, err := json.Marshal(map[string]string{
+		"default_marshal": "DefaultMarshal",
+		"omit_empty":      "OmitEmpty"})
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -330,9 +336,11 @@ func TestMarshal_Recursive(t *testing.T) {
 		"some_data": "SomeData",
 		"groups_data": []map[string]interface{}{
 			{
+				"default_marshal":       "DefaultMarshal",
 				"only_group_test":       "OnlyGroupTest",
 				"omit_empty_group_test": "OmitEmptyGroupTest",
 				"group_test_and_other":  "GroupTestAndOther",
+				"omit_empty":            "OmitEmpty",
 				"map_string_struct": map[string]map[string]bool{
 					"firstModel": {
 						"something": true,
@@ -506,7 +514,7 @@ func TestMarshal_EmbeddedField(t *testing.T) {
 }
 
 type TestMarshal_EmbeddedEmpty struct {
-	Foo string
+	Foo string `groups:"nothing"`
 }
 
 type TestMarshal_EmbeddedParentEmpty struct {
@@ -537,18 +545,18 @@ func TestMarshal_EmbeddedFieldEmpty(t *testing.T) {
 
 type InterfaceableBeta struct {
 	Integer int    `json:"integer" groups:"safe"`
-	Secret  string `json:"secret"`
+	Secret  string `json:"secret" groups:"unsafe"`
 }
 type InterfaceableCharlie struct {
 	Integer int    `json:"integer" groups:"safe"`
-	Secret  string `json:"secret"`
+	Secret  string `json:"secret" groups:"unsafe"`
 }
 type ArrayOfInterfaceable []CanHazInterface
 type CanHazInterface interface {
 }
 type InterfacerAlpha struct {
 	Plaintext     string               `json:"plaintext" groups:"safe"`
-	Secret        string               `json:"secret"`
+	Secret        string               `json:"secret" groups:"unsafe"`
 	Nested        InterfaceableBeta    `json:"nested" groups:"safe"`
 	Interfaceable ArrayOfInterfaceable `json:"interfaceable" groups:"safe"`
 }
@@ -563,7 +571,7 @@ func TestMarshal_ArrayOfInterfaceable(t *testing.T) {
 		},
 		ArrayOfInterfaceable{
 			InterfaceableBeta{200, "Still a secret good"},
-			InterfaceableCharlie{300, "Still a secret exellect"},
+			InterfaceableCharlie{300, "Still a secret excellent"},
 		}}
 
 	o := &Options{


### PR DESCRIPTION
When playing around with Sheriff, I noticed that the default behavior is to omit fields when no groups are specified.

This ends up making sheriff infectious-- if you want to filter out a field, say, you need to annotate every other field with an `all` annotation or the like, or the field will never be marshaled. 

I've changed the behavior so that if a field has no groups annotation, it's always marshaled.

I also converted this to a go module.