### PR TITLE
Fix empty / nil map distinction

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -206,6 +206,9 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 		return Marshal(options, val)
 	}
 	if k == reflect.Slice {
+		if v.IsNil() {
+			return nil, nil
+		}
 		l := v.Len()
 		dest := make([]interface{}, l)
 		for i := 0; i < l; i++ {

--- a/sheriff.go
+++ b/sheriff.go
@@ -218,9 +218,13 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 		return dest, nil
 	}
 	if k == reflect.Map {
+		if v.IsNil() {
+			return nil, nil
+		}
 		mapKeys := v.MapKeys()
 		if len(mapKeys) == 0 {
-			return nil, nil
+			dest := make(map[string]interface{})
+			return dest, nil
 		}
 		if mapKeys[0].Kind() != reflect.String {
 			return nil, MarshalInvalidTypeError{t: mapKeys[0].Kind(), data: val}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -764,3 +764,49 @@ func TestNilMapAlias(t *testing.T) {
 
 	assert.Equal(t, string(expected), string(actual))
 }
+
+type ArrayAliasContainer struct {
+	Foo ArrayAlias `json:"foo"`
+}
+
+type ArrayAlias []int
+
+func TestEmptyArrayAlias(t *testing.T) {
+	v := ArrayAliasContainer{
+		Foo: ArrayAlias{},
+	}
+	o := &Options{}
+
+	actualMap, err := Marshal(o, v)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"foo": ArrayAlias{},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}
+
+func TestNilArrayAlias(t *testing.T) {
+	v := ArrayAliasContainer{
+		Foo: nil,
+	}
+	o := &Options{}
+
+	actualMap, err := Marshal(o, v)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"foo": nil,
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -718,3 +718,49 @@ func TestAnonymousWithNoGroups(t *testing.T) {
 
 	assert.Equal(t, string(expected), string(actual))
 }
+
+type MapAliasContainer struct {
+	Foo MapAlias `json:"foo"`
+}
+
+type MapAlias map[string]bool
+
+func TestEmptyMapAlias(t *testing.T) {
+	v := MapAliasContainer{
+		Foo: MapAlias{},
+	}
+	o := &Options{}
+
+	actualMap, err := Marshal(o, v)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"foo": MapAlias{},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}
+
+func TestNilMapAlias(t *testing.T) {
+	v := MapAliasContainer{
+		Foo: nil,
+	}
+	o := &Options{}
+
+	actualMap, err := Marshal(o, v)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"foo": nil,
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}


### PR DESCRIPTION
Minor bug in sheriff-- it wasn't distinguishing empty maps from nil maps.

Same problem existed with arrays.