### PR TITLE
fix nil value panic

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -52,6 +52,11 @@ type Marshaller interface {
 // In all other cases we can't derive the type in a meaningful way and is therefore an `interface{}`.
 func Marshal(options *Options, data interface{}) (interface{}, error) {
 	v := reflect.ValueOf(data)
+	// If data was nil, bail here to avoid panicking. We didn't want to marshal that anyway.
+	if !v.IsValid() {
+		return nil, nil
+	}
+
 	t := v.Type()
 
 	// Initialise nestedGroupsMap,


### PR DESCRIPTION
I haven't quite tracked down how this is happening (can't reproduce locally), but apparently in some cases `data` can be `nil` when passed in to Marshal. Doing `reflect.ValueOf(nil)` and then trying to do anything with that causes a panic (instead of doing something reasonable like, say, returning `Nil` as the `Type()`.
Just skipping the value should be fine for now, it will end up as nil in the output map which seems like what we would want here anyway. Will file a ticket to track down what's actually happening.