### PR TITLE
Support types other than string in map keys

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-version v1.2.1-0.20191009193637-2046c9d0f0b0 h1:8gXJgyR86/nGv7IqrnmnKJVNxC9APdvAVSxc9mGxfKk=
+github.com/hashicorp/go-version v1.2.1-0.20191009193637-2046c9d0f0b0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/sheriff.go
+++ b/sheriff.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	version "github.com/hashicorp/go-version"
@@ -229,20 +230,43 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 			dest := make(map[string]interface{})
 			return dest, nil
 		}
-		if mapKeys[0].Kind() != reflect.String {
-			return nil, MarshalInvalidTypeError{t: mapKeys[0].Kind(), data: val}
-		}
 		dest := make(map[string]interface{})
 		for _, key := range mapKeys {
 			d, err := marshalValue(options, v.MapIndex(key))
 			if err != nil {
 				return nil, err
 			}
-			dest[key.Interface().(string)] = d
+			keyString, err := coerceMapKeyToString(key)
+			if err != nil {
+				return nil, err
+			}
+			dest[keyString] = d
 		}
 		return dest, nil
 	}
 	return val, nil
+}
+
+func coerceMapKeyToString(v reflect.Value) (string, error) {
+	// Copied from encode.go in the official json package
+
+	if v.Kind() == reflect.String {
+		return v.String(), nil
+	}
+
+	if tm, ok := v.Interface().(encoding.TextMarshaler); ok {
+		buf, err := tm.MarshalText()
+		return string(buf), err
+	}
+
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(v.Uint(), 10), nil
+	}
+
+	return "", MarshalInvalidTypeError{t: v.Kind(), data: v.Interface()}
 }
 
 // contains check if a given key is contained in a slice of strings.


### PR DESCRIPTION
Sheriff currently only supports marshalling maps with string keys. This is a pretty significant limitation compared to the built-in json package.
Unfortunately, the built-in json package doesn't export its functionality for dealing with map keys, but at least it's fairly small. I've copied the relevant function from the go source and wired it in.

Debugging this problem was made more difficult by the fact that we generally don't check for errors from `json.Marshal` in gonfalon. This was fine when we were using the built-in one as we understood the small set of errors it could throw, but now that we're using this library we should probably check everywhere.